### PR TITLE
Update image.go

### DIFF
--- a/image.go
+++ b/image.go
@@ -49,8 +49,8 @@ func resizeByNearest(
 	for y := 0; y < dstSize.Y; y++ {
 		for x := 0; x < dstSize.X; x++ {
 			r, g, b, a = src.At(
-				int(float64(x)*xScale+float64(xMin)),
-				int(float64(y)*yScale+float64(yMin))).RGBA()
+				int(float64(x)*xScale)+xMin,
+				int(float64(y)*yScale)+yMin).RGBA()
 			dst.Set(x, y, color.RGBA{
 				uint8(r >> 8),
 				uint8(g >> 8),


### PR DESCRIPTION
Fix floating point calculation error.

When xMin>0 or yMin>0, it may cause calculation errors, such as float64(x)*xScale is 12.999999999999998, xMin is 364, int(float64(x)*xScale+float64(xMin)) will get the result 377, which expected 376.
